### PR TITLE
Add Squeeze merge strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ pre-existing data.
 *   `"New"`: Only upload the data if there is no prior data for any of the
         claims to be added. I.e. drop all data if any of the proposed Pids or
         caption languages are already present.
+*   `"Squeeze"`: Only upload those parts of the data for which there are no
+        prior claims. I.e. drop any statements where the Pid or caption language
+        is already present.
 *   `"Blind"` (not generally recommended): Upload the data without regards to
         what is already there. May overwrite pre-existing captions and add
         duplicate statements.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To upload data to a file that already contains some structured data add the
 `strategy` argument to the call using one of the [named merge strategies](#merge-strategies).
 
 ### Merge strategies
-There are three allowed strategies for merging the provided data with any
+There are four allowed strategies for merging the provided data with any
 pre-existing data.
 *   `None` (default): Only upload the data if no prior data exists.
 *   `"New"`: Only upload the data if there is no prior data for any of the

--- a/pywikibotsdc/sdc_support.py
+++ b/pywikibotsdc/sdc_support.py
@@ -64,7 +64,13 @@ def upload_single_sdc_data(file_page, sdc_data, target_site=None,
 
     # check if there is Structured Data already and resolve what to do
     # raise SdcException if merge is not possible
-    merge_strategy(media_identifier, target_site, sdc_data, strategy)
+    skipped = merge_strategy(media_identifier, target_site, sdc_data, strategy)
+    if skipped:
+        pywikibot.log(
+            '{0} - Conflict with existing values. Dropping the following '
+            'properties and caption languages{}.'.format(
+                file_page.title(),
+                ', '.join([', '.join(v) for v in skipped.values()])))
 
     # Translate from internal sdc data format to that expected by MediaWiki.
     try:

--- a/pywikibotsdc/sdc_support.py
+++ b/pywikibotsdc/sdc_support.py
@@ -142,51 +142,54 @@ def merge_strategy(media_identifier, target_site, sdc_data, strategy):
     """
     # @todo: Consider one more strategy: nuke (delete all pre-existing data)
     prior_data = _get_existing_structured_data(media_identifier, target_site)
-    if prior_data:
-        if not strategy:
+    if not prior_data:
+        # even unknown strategies should pass if there is no prior data
+        return
+
+    if not strategy:
+        raise SdcException(
+            'warning', 'pre-existing sdc-data',
+            ('Found pre-existing SDC data, no new data will be added. '
+             'Found data: {}'.format(prior_data))
+        )
+    elif strategy.lower() in ('new', 'squeeze'):
+        pre_pids = prior_data['statements'].keys()
+        pre_langs = prior_data['labels'].keys()
+        new_langs = sdc_data.get('caption', {}).keys()
+
+        if strategy.lower() == 'squeeze':
+            pid_clash = set(pre_pids).intersection(sdc_data.keys())
+            lang_clash = set(pre_langs).intersection(new_langs)
+            for pid in pid_clash:
+                sdc_data.pop(pid, None)
+            for lang in lang_clash:
+                sdc_data['caption'].pop(lang, None)
+            if (not any(is_prop_key(key) for key in sdc_data.keys())
+                    and not sdc_data.get('caption')):
+                # warn if not data left to upload
+                raise SdcException(
+                    'warning', 'all conflicting pre-existing sdc-data',
+                    ('Found pre-existing SDC data, no new non-conflicting '
+                     'data could be added. Found data: {}'.format(
+                         prior_data))
+                )
+            elif pid_clash or lang_clash:
+                return {'pids': pid_clash, 'langs': lang_clash}
+        elif (not set(pre_pids).isdisjoint(sdc_data.keys())
+                or not set(pre_langs).isdisjoint(new_langs)):
             raise SdcException(
-                'warning', 'pre-existing sdc-data',
+                'warning', 'conflicting pre-existing sdc-data',
                 ('Found pre-existing SDC data, no new data will be added. '
                  'Found data: {}'.format(prior_data))
             )
-        elif strategy.lower() in ('new', 'squeeze'):
-            pre_pids = prior_data['statements'].keys()
-            pre_langs = prior_data['labels'].keys()
-            new_langs = sdc_data.get('caption', {}).keys()
-
-            if strategy.lower() == 'squeeze':
-                pid_clash = set(pre_pids).intersection(sdc_data.keys())
-                lang_clash = set(pre_langs).intersection(new_langs)
-                for pid in pid_clash:
-                    sdc_data.pop(pid, None)
-                for lang in lang_clash:
-                    sdc_data['caption'].pop(lang, None)
-                if (not any(is_prop_key(key) for key in sdc_data.keys())
-                        and not sdc_data.get('caption')):
-                    # warn if not data left to upload
-                    raise SdcException(
-                        'warning', 'all conflicting pre-existing sdc-data',
-                        ('Found pre-existing SDC data, no new non-conflicting '
-                         'data could be added. Found data: {}'.format(
-                             prior_data))
-                    )
-                elif pid_clash or lang_clash:
-                    return {'pids': pid_clash, 'langs': lang_clash}
-            elif (not set(pre_pids).isdisjoint(sdc_data.keys())
-                    or not set(pre_langs).isdisjoint(new_langs)):
-                raise SdcException(
-                    'warning', 'conflicting pre-existing sdc-data',
-                    ('Found pre-existing SDC data, no new data will be added. '
-                     'Found data: {}'.format(prior_data))
-                )
-        elif strategy.lower() not in STRATEGIES:
-            raise ValueError(
-                'The `strategy` parameter must be None, "{0}" or "{1}" '
-                'but "{2}" was provided'.format(
-                    '", "'.join([s.capitalize() for s in STRATEGIES[:-1]]),
-                    STRATEGIES[-1].capitalize(),
-                    strategy))
-        # pass if strategy is "Blind"
+    elif strategy.lower() not in STRATEGIES:
+        raise ValueError(
+            'The `strategy` parameter must be None, "{0}" or "{1}" '
+            'but "{2}" was provided'.format(
+                '", "'.join([s.capitalize() for s in STRATEGIES[:-1]]),
+                STRATEGIES[-1].capitalize(),
+                strategy))
+    # pass if strategy is "Blind"
 
 
 def format_sdc_payload(target_site, data):

--- a/tests/test_sdc_support.py
+++ b/tests/test_sdc_support.py
@@ -280,7 +280,7 @@ class TestMergeStrategy(unittest.TestCase):
         self.mock__get_existing_structured_data.return_value = data
 
     def test_merge_strategy_any_strategy_no_data(self):
-        """Any strategy, even an unknown one, should pass if no prior data."""
+        # Any strategy, even an unknown one, should pass if no prior data.
         for strategy in (None, 'new', 'blind', 'squeeze', 'foo'):
             input_data = deepcopy(self.base_sdc)
             r = merge_strategy(
@@ -306,7 +306,7 @@ class TestMergeStrategy(unittest.TestCase):
         input_data = deepcopy(self.base_sdc)
         self.set_mock_response_data(
             captions={'fr': 'hello'}, claims={'P456': [{}]})
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'New')
+        r = merge_strategy(self.mid, self.mock_site, input_data, 'New')
         self.assertEquals(input_data, self.base_sdc)
         self.assertIsNone(r)
 
@@ -328,7 +328,7 @@ class TestMergeStrategy(unittest.TestCase):
         input_data = deepcopy(self.base_sdc)
         self.set_mock_response_data(
             captions={'fr': 'hello'}, claims={'P456': [{}]})
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'Blind')
+        r = merge_strategy(self.mid, self.mock_site, input_data, 'Blind')
         self.assertEquals(input_data, self.base_sdc)
         self.assertIsNone(r)
 
@@ -336,7 +336,7 @@ class TestMergeStrategy(unittest.TestCase):
         input_data = deepcopy(self.base_sdc)
         self.set_mock_response_data(
             captions={'sv': 'hello'}, claims={'P123': [{}]})
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'Blind')
+        r = merge_strategy(self.mid, self.mock_site, input_data, 'Blind')
         self.assertEquals(input_data, self.base_sdc)
         self.assertIsNone(r)
 
@@ -344,7 +344,7 @@ class TestMergeStrategy(unittest.TestCase):
         input_data = deepcopy(self.base_sdc)
         self.set_mock_response_data(
             captions={'fr': 'hello'}, claims={'P456': [{}]})
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'Squeeze')
+        r = merge_strategy(self.mid, self.mock_site, input_data, 'Squeeze')
         self.assertEquals(input_data, self.base_sdc)
         self.assertIsNone(r)
 
@@ -355,7 +355,7 @@ class TestMergeStrategy(unittest.TestCase):
         self.set_mock_response_data(
             captions={'sv': 'hello', 'fr': 'hi'}, claims={'P123': [{}]})
         r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'Squeeze')
-        self.assertEquals(expected_data, self.base_sdc)
+        self.assertEquals(self.base_sdc, expected_data)
         self.assertEquals(r, {'pids': {'P123'}, 'langs': {'sv'}})
 
     def test_merge_strategy_squeeze_strategy_all_conflicting_data(self):

--- a/tests/test_sdc_support.py
+++ b/tests/test_sdc_support.py
@@ -279,9 +279,14 @@ class TestMergeStrategy(unittest.TestCase):
         }
         self.mock__get_existing_structured_data.return_value = data
 
-    def test_merge_strategy_unknown_strategy_no_data(self):
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'foo')
-        self.assertIsNone(r)
+    def test_merge_strategy_any_strategy_no_data(self):
+        """Any strategy, even an unknown one, should pass if no prior data."""
+        for strategy in (None, 'new', 'blind', 'squeeze', 'foo'):
+            input_data = deepcopy(self.base_sdc)
+            r = merge_strategy(
+                self.mid, self.mock_site, input_data, strategy)
+            self.assertIsNone(r)
+            self.assertEquals(input_data, self.base_sdc)
 
     def test_merge_strategy_unknown_strategy_some_data_raises(self):
         self.set_mock_response_data(captions={'sv': 'hello'})
@@ -291,23 +296,11 @@ class TestMergeStrategy(unittest.TestCase):
             str(ve.exception).startswith('The `strategy` parameter'))
         self.assertTrue('foo' in str(ve.exception))
 
-    def test_merge_strategy_none_strategy_no_data(self):
-        input_data = deepcopy(self.base_sdc)
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, None)
-        self.assertEquals(input_data, self.base_sdc)
-        self.assertIsNone(r)
-
     def test_merge_strategy_none_strategy_some_non_conflicting_data(self):
         self.set_mock_response_data(captions={'fr': 'hello'})
         with self.assertRaises(SdcException) as se:
             merge_strategy(self.mid, self.mock_site, self.base_sdc, None)
         self.assertEquals(se.exception.data, 'pre-existing sdc-data')
-
-    def test_merge_strategy_new_strategy_no_data(self):
-        input_data = deepcopy(self.base_sdc)
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'New')
-        self.assertEquals(input_data, self.base_sdc)
-        self.assertIsNone(r)
 
     def test_merge_strategy_new_strategy_some_non_conflicting_data(self):
         input_data = deepcopy(self.base_sdc)
@@ -331,12 +324,6 @@ class TestMergeStrategy(unittest.TestCase):
         self.assertEquals(
             se.exception.data, 'conflicting pre-existing sdc-data')
 
-    def test_merge_strategy_blind_strategy_no_data(self):
-        input_data = deepcopy(self.base_sdc)
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'Blind')
-        self.assertEquals(input_data, self.base_sdc)
-        self.assertIsNone(r)
-
     def test_merge_strategy_blind_strategy_some_non_conflicting_data(self):
         input_data = deepcopy(self.base_sdc)
         self.set_mock_response_data(
@@ -350,12 +337,6 @@ class TestMergeStrategy(unittest.TestCase):
         self.set_mock_response_data(
             captions={'sv': 'hello'}, claims={'P123': [{}]})
         r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'Blind')
-        self.assertEquals(input_data, self.base_sdc)
-        self.assertIsNone(r)
-
-    def test_merge_strategy_squeeze_strategy_no_data(self):
-        input_data = deepcopy(self.base_sdc)
-        r = merge_strategy(self.mid, self.mock_site, self.base_sdc, 'Squeeze')
         self.assertEquals(input_data, self.base_sdc)
         self.assertIsNone(r)
 


### PR DESCRIPTION
The 'Squeeze' strategy adds any claims (Pids or captions) which are
not present in the prior data. Anything already present is dropped.