### PR TITLE
Add Nuke strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To upload data to a file that already contains some structured data add the
 `strategy` argument to the call using one of the [named merge strategies](#merge-strategies).
 
 ### Merge strategies
-There are four allowed strategies for merging the provided data with any
+There are five allowed strategies for merging the provided data with any
 pre-existing data.
 *   `None` (default): Only upload the data if no prior data exists.
 *   `"New"`: Only upload the data if there is no prior data for any of the
@@ -42,6 +42,11 @@ pre-existing data.
 *   `"Blind"` (not generally recommended): Upload the data without regards to
         what is already there. May overwrite pre-existing captions and add
         duplicate statements.
+*   `"Nuke"` (not generally recommended): Delete all prior data before
+        uploading the new data. This should probably only be used if you
+        uploaded the original data then spotted that it was wrong. Even then
+        it's probably worth checking that the file hasn't been edited since
+        the original upload.
 
 ## SDC in-data format
 

--- a/pywikibotsdc/sdc_support.py
+++ b/pywikibotsdc/sdc_support.py
@@ -20,7 +20,7 @@ from pywikibotsdc.sdc_exception import SdcException
 _COMMONS_MEDIA_FILE_SITE = None  # pywikibot.Site('commons', 'commons')
 DEFAULT_EDIT_SUMMARY = \
     'Added {count} structured data statement(s) #pwbsdc'
-STRATEGIES = ('new', 'blind', 'squeeze')
+STRATEGIES = ('new', 'blind', 'squeeze', 'nuke')
 
 
 def _get_commons():
@@ -94,6 +94,8 @@ def upload_single_sdc_data(file_page, sdc_data, target_site=None,
         'summary': summary.format(count=num_statements),
         'bot': target_site.has_right('bot')
     }
+    if strategy.lower() == 'nuke':
+        payload['clear'] = 1
 
     request = target_site._simple_request(**payload)
     try:
@@ -135,12 +137,11 @@ def merge_strategy(media_identifier, target_site, sdc_data, strategy):
     @param target_site: pywikibot.Site object to which file should be uploaded
     @param sdc_data: internally formatted Structured Data in json format
     @param strategy: Strategy used for merging uploaded data with pre-existing
-        data. Allowed values are None, "New", "Blind" and "Squeeze".
+        data. Allowed values are None, "New", "Blind", "Squeeze" and "Nuke".
     @return: dict of pids and caption languages removed from sdc_data due to
         conflicts.
     @raises: ValueError, SdcException
     """
-    # @todo: Consider one more strategy: nuke (delete all pre-existing data)
     prior_data = _get_existing_structured_data(media_identifier, target_site)
     if not prior_data:
         # even unknown strategies should pass if there is no prior data
@@ -189,7 +190,7 @@ def merge_strategy(media_identifier, target_site, sdc_data, strategy):
                 '", "'.join([s.capitalize() for s in STRATEGIES[:-1]]),
                 STRATEGIES[-1].capitalize(),
                 strategy))
-    # pass if strategy is "Blind"
+    # pass if strategy is "Blind" or "Nuke"
 
 
 def format_sdc_payload(target_site, data):

--- a/pywikibotsdc/sdc_support.py
+++ b/pywikibotsdc/sdc_support.py
@@ -31,6 +31,18 @@ def _get_commons():
     return _COMMONS_MEDIA_FILE_SITE
 
 
+def _submit_data(target_site, payload):
+    """
+    Submit the Structured Data for upload.
+
+    @param target_site: pywikibot.Site where data is uploaded.
+    @param payload: request formatted for the MediaWiki Action API
+    @raises: pywikibot.data.api.APIError
+    """
+    request = target_site._simple_request(**payload)
+    request.submit()
+
+
 def upload_single_sdc_data(file_page, sdc_data, target_site=None,
                            strategy=None, summary=None):
     """
@@ -50,6 +62,7 @@ def upload_single_sdc_data(file_page, sdc_data, target_site=None,
     @return: Number of added statements
     @raises: ValueError, SdcException
     """
+    # support either file_name+Site or file_page as input
     if isinstance(file_page, pywikibot.FilePage):
         if target_site and target_site != file_page.site:
             raise ValueError(
@@ -94,12 +107,11 @@ def upload_single_sdc_data(file_page, sdc_data, target_site=None,
         'summary': summary.format(count=num_statements),
         'bot': target_site.has_right('bot')
     }
-    if strategy.lower() == 'nuke':
+    if strategy and strategy.lower() == 'nuke':
         payload['clear'] = 1
 
-    request = target_site._simple_request(**payload)
     try:
-        request.submit()
+        _submit_data(target_site, payload)
     except pywikibot.data.api.APIError as error:
         raise SdcException(
             'error', error, '{0} - Uploading SDC data failed: {1}'.format(

--- a/tests/test_sdc_support.py
+++ b/tests/test_sdc_support.py
@@ -281,7 +281,7 @@ class TestMergeStrategy(unittest.TestCase):
 
     def test_merge_strategy_any_strategy_no_data(self):
         # Any strategy, even an unknown one, should pass if no prior data.
-        for strategy in (None, 'new', 'blind', 'squeeze', 'foo'):
+        for strategy in (None, 'new', 'blind', 'squeeze', 'nuke', 'foo'):
             input_data = deepcopy(self.base_sdc)
             r = merge_strategy(
                 self.mid, self.mock_site, input_data, strategy)
@@ -365,3 +365,19 @@ class TestMergeStrategy(unittest.TestCase):
             merge_strategy(self.mid, self.mock_site, self.base_sdc, 'Squeeze')
         self.assertEquals(
             se.exception.data, 'all conflicting pre-existing sdc-data')
+
+    def test_merge_strategy_nuke_strategy_some_non_conflicting_data(self):
+        input_data = deepcopy(self.base_sdc)
+        self.set_mock_response_data(
+            captions={'fr': 'hello'}, claims={'P456': [{}]})
+        r = merge_strategy(self.mid, self.mock_site, input_data, 'Nuke')
+        self.assertEquals(input_data, self.base_sdc)
+        self.assertIsNone(r)
+
+    def test_merge_strategy_nuke_strategy_some_conflicting_data(self):
+        input_data = deepcopy(self.base_sdc)
+        self.set_mock_response_data(
+            captions={'sv': 'hello'}, claims={'P123': [{}]})
+        r = merge_strategy(self.mid, self.mock_site, input_data, 'Nuke')
+        self.assertEquals(input_data, self.base_sdc)
+        self.assertIsNone(r)


### PR DESCRIPTION
Adds the nuke strategy which deletes all pre-existing data before
uploading the new one.